### PR TITLE
small css updates for mobile

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -4,4 +4,9 @@ body { background-color: var(--bs-dark) !important;
 
 .row{
   margin-bottom: 5%;
+  --bs-gutter-x: 0;
+}
+
+.form-control {
+  width: 99%;
 }


### PR DESCRIPTION
Makes buttons and input selector stay in the container in mobile views.

I'm certain this isn't the best way to do this, but my css skills are nothing to brag about. This particular issue had been bothering me for a while though and this seems to be enough to make everything fit in the container as expected on mobile screens. If you know of a better way to handle this however, I'm definitely open to it!
![image](https://user-images.githubusercontent.com/70827496/159207194-7655e689-db31-43dc-a7a5-cffc9c2b592b.png)

Desktop version still looks pretty much the same:
![image](https://user-images.githubusercontent.com/70827496/159208493-19e26864-cc99-43bd-a247-a607f70522ff.png)
