### PR TITLE
Publish container to ghcr

### DIFF
--- a/.github/workflows/ghcr-release.yml
+++ b/.github/workflows/ghcr-release.yml
@@ -1,0 +1,35 @@
+name: Create and publish a container image
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ We understand that secrets are sensitive and people may not want to use a public
 ## docker-compose
 We have provided a `docker-compose` file to easily build and host a functional TMPNOTES system.
 ```
-docker-compose build
 docker-compose up
 ```
 Navigate to [localhost:5000](http://localhost:5000) and you will see your own tmpnotes instance running.
 
 ## Docker image
-*Coming soon! We will publish a docker image you can use directly on your infrastructure.*
+```
+docker pull ghcr.io/soraro/tmpnotes:latest
+```
+View all versions on the [ghcr package page](https://github.com/soraro/tmpnotes/pkgs/container/tmpnotes)
 
 ## Helm Chart
 *Coming soon!*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       timeout: 1s
       retries: 10
   tmpnotes:
-    build: .
+    image: "ghcr.io/soraro/tmpnotes:latest"
     ports:
       - "5000:5000"
     environment:


### PR DESCRIPTION
closes #3 

Tested with a tag `v0.0.1` and you can see the resulting image created here: https://github.com/soraro/tmpnotes/pkgs/container/tmpnotes