### PR TITLE
Adding server side encryption to notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 Temporary notes that disappear after reading
 
 # How it works
-TMPNOTES is a system to share secrets in a reasonably secure, temporary way. TMPNOTES uses a [redis](https://redis.io/) cache to store notes. Notes are immediately purged once a note has been read, or the user-defined TTL (time to live) has expired. Notes are only allowed a maximum TTL of 24 hours.
+TMPNOTES is a system to share secrets in a reasonably secure, temporary way. TMPNOTES uses a [redis](https://redis.io/) cache to store notes. Notes are immediately purged once a note has been read, or the user-defined TTL (time to live) has expired. Notes are only allowed a maximum TTL of 24 hours. All notes are encrypted [server side](docs/server-side-encryption.md), and only the user who generated the note has the full key.
 
 # Privacy
-We will never read notes that are stored in the redis database, and there are no backups that are ever taken for [tmpnotes.com](https://tmpnotes.com). The website has an encryption feature that can encrypt your note in the browser *before* it is sent to the server. This ensures that even if someone did view the database, the data would not be readable. The codebase is also small, and relatively easy to audit.
+All notes are encrypted using our [server side encryption feature](docs/server-side-encryption.md) so we can not, and will not ever attempt to read notes stored in the redis database. Since these notes are meant to be temporary, no database backups are ever taken for [tmpnotes.com](https://tmpnotes.com). In addition, the website has a feature that can encrypt your note in the browser *before* it is sent to the server. These measures ensure that even if someone did view the database, the data would not be readable. The codebase is also small, and relatively easy to audit.
 
 If you don't want to send your information to [tmpnotes.com](https://tmpnotes.com), we don't blame you! We want to make this project easy to run yourself if that is desired. We will host [tmpnotes.com](https://tmpnotes.com) as long as it does not become frequently abused or prohibitively expensive for us to do so.
 

--- a/docs/server-side-encryption.md
+++ b/docs/server-side-encryption.md
@@ -1,0 +1,28 @@
+# Server side encryption
+[This PR](https://github.com/soraro/tmpnotes/pull/29) added a way to transparently encrypt a note on the server side so an administrator can not read notes stored in Redis. 
+
+## How it works:
+The note is encrypted using AES256 with a key derived from the generated uuid in the following way. A uuid has 32 characters, so the first 8 characters are taken, and that is used as the Redis key. The remaining 24 characters are hashed using SHA512. Using the result of that hash we take the first 32 characters as the encryption key. The note string is encrypted, and hex encoded. This hex encoded text is then what is stored in Redis.
+
+Example on a locally running tmpnotes instance:
+```
+$ curl -X POST localhost:5000/new -d '{"message": "test note", "ttl": 1}'
+a66b0dcabc604ab39c4dfc4884eb428e
+
+# on the redis server:
+127.0.0.1:6379> get a66b0dca
+"1ee49f9de0ebfcfeacaad9ff699a15f64c3cf1608ea847a33c4a02f2b88ce1d92a159df1a7"
+```
+Logs from this interaction:
+```
+{"level":"info","msg":"Server listening at :5000","time":"2022-04-15T10:26:30-06:00"}
+{"level":"info","msg":"/new","time":"2022-04-15T10:32:47-06:00"}
+{"level":"info","msg":"a66b0dca","time":"2022-04-15T10:50:34-06:00"}
+```
+
+## Considerations:
+* This code ONLY logs the first 8 characters of the uuid, making it very difficult to derive the full key from incoming requests. The code will never store the full uuid.
+* Using the first 8 characters of the generated uuid gives us more opportunities for collisions, but since notes are only kept in Redis for a maximum of 24 hours, it should be *unique enough*:  `16^8 = 4,294,967,296` unique combinations
+
+# Other thoughts:
+It is still highly recommended to use the optional encryption key feature so you are the sole owner of the key material and the server side only sees the encrypted data. Additionally, you can use tmpnotes like an API and encrypt your string however you see fit and send the characters to us that way via curl or any other HTTP client.

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -1,0 +1,59 @@
+// This is taken from https://github.com/gtank/cryptopasta
+
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"io"
+)
+
+// Encrypt encrypts data using 256-bit AES-GCM.  This both hides the content of
+// the data and provides a check that it hasn't been altered. Output takes the
+// form nonce|ciphertext|tag where '|' indicates concatenation.
+func Encrypt(plaintext []byte, key *[32]byte) (ciphertext []byte, err error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Decrypt decrypts data using 256-bit AES-GCM.  This both hides the content of
+// the data and provides a check that it hasn't been altered. Expects input
+// form nonce|ciphertext|tag where '|' indicates concatenation.
+func Decrypt(ciphertext []byte, key *[32]byte) (plaintext []byte, err error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, errors.New("malformed ciphertext")
+	}
+
+	return gcm.Open(nil,
+		ciphertext[:gcm.NonceSize()],
+		ciphertext[gcm.NonceSize():],
+		nil,
+	)
+}

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,0 +1,50 @@
+// This is taken from https://github.com/gtank/cryptopasta
+
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"testing"
+)
+
+func TestEncryptDecryptGCM(t *testing.T) {
+	randomKey := &[32]byte{}
+	_, err := io.ReadFull(rand.Reader, randomKey[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gcmTests := []struct {
+		plaintext []byte
+		key       *[32]byte
+	}{
+		{
+			plaintext: []byte("Hello, world!"),
+			key:       randomKey,
+		},
+	}
+
+	for _, tt := range gcmTests {
+		ciphertext, err := Encrypt(tt.plaintext, tt.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		plaintext, err := Decrypt(ciphertext, tt.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(plaintext, tt.plaintext) {
+			t.Errorf("plaintexts don't match")
+		}
+
+		ciphertext[0] ^= 0xff
+		_, err = Decrypt(ciphertext, tt.key)
+		if err == nil {
+			t.Errorf("gcmOpen should not have worked, but did")
+		}
+	}
+}

--- a/internal/crypto/hash.go
+++ b/internal/crypto/hash.go
@@ -1,0 +1,19 @@
+// This is taken from https://github.com/gtank/cryptopasta
+
+package crypto
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+)
+
+// Hash generates a hash of data using HMAC-SHA-512/256. The tag is intended to
+// be a natural-language string describing the purpose of the hash, such as
+// "hash file for lookup key" or "master secret to client secret".  It serves
+// as an HMAC "key" and ensures that different purposes will have different
+// hash output. This function is NOT suitable for hashing passwords.
+func Hash(tag string, data []byte) []byte {
+	h := hmac.New(sha512.New512_256, []byte(tag))
+	h.Write(data)
+	return h.Sum(nil)
+}

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -152,3 +152,19 @@ func Test_noteType(t *testing.T) {
 		})
 	}
 }
+
+func Test_encryptDecrypt(t *testing.T) {
+	cipherText, err := encryptNote("test", "44ec4dd68dd0aee62aedf766")
+	if err != nil {
+		t.Errorf("Encryption failed: %s", err)
+	}
+
+	plainText, err := decryptNote(cipherText, "44ec4dd68dd0aee62aedf766")
+	if err != nil {
+		t.Errorf("Decryption failed: %s", err)
+	}
+
+	if plainText != "test" {
+		t.Errorf("Decrypted text should be \"test\" but instead got: %s", plainText)
+	}
+}


### PR DESCRIPTION
# Current state
When you create a note on tmpnotes, a uuid is returned to you which is also used as the key inside of Redis to store the note text. Currently, this text is stored in clear text on the Redis instance unless you use the optional encryption key (that encrypts the note in your browser before sending it to the server). 

Example on a locally running tmpnotes instance:
```
$ curl -X POST localhost:5000/new -d '{"message": "test note", "ttl": 1}'
81add356cab24e6787b45a5befab5a69

# on the redis server:
127.0.0.1:6379> get 81add356cab24e6787b45a5befab5a69
"test note"
```
# Adding server side encryption
This PR adds a way to transparently encrypt a note on the server side so an administrator could not read notes stored in Redis. 

## How it works:
The note is encrypted using AES256 with a key derived from the generated uuid in the following way. A uuid has 32 characters, so the first 8 characters are taken, and that is used as the Redis key. The remaining 24 characters are hashed using SHA512. Using the result of that hash we take the first 32 characters as the encryption key. The note string is encrypted, and hex encoded. This hex encoded text is then what is stored in Redis.

Example on a locally running tmpnotes instance:
```
$ curl -X POST localhost:5000/new -d '{"message": "test note", "ttl": 1}'
a66b0dcabc604ab39c4dfc4884eb428e

# on the redis server:
127.0.0.1:6379> get a66b0dca
"1ee49f9de0ebfcfeacaad9ff699a15f64c3cf1608ea847a33c4a02f2b88ce1d92a159df1a7"
```
Logs from this interaction:
```
{"level":"info","msg":"Server listening at :5000","time":"2022-04-15T10:26:30-06:00"}
{"level":"info","msg":"/new","time":"2022-04-15T10:32:47-06:00"}
{"level":"info","msg":"a66b0dca","time":"2022-04-15T10:50:34-06:00"}
```

## Considerations:
* This code ONLY logs the first 8 characters of the uuid, making it very difficult to derive the full key from incoming requests. The code will never store the full uuid.
* Using the first 8 characters of the generated uuid gives us more opportunities for collisions, but since notes are only kept in Redis for a maximum of 24 hours, it should be *unique enough*:  `16^8 = 4,294,967,296` unique combinations

# Final thoughts:
It is still highly recommended to use the optional encryption key feature so you are the sole owner of the key material and the server side only sees the encrypted data. Additionally, you can use tmpnotes like an API and encrypt your string however you see fit and send the characters to us that way via curl or any other HTTP client. Hopefully this will be a good first attempt at obfuscating the notes on the server transparently without any user input. 