### PR TITLE
Moving home link css to custom.css so we can add a stricter CSP

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -27,3 +27,7 @@ body { background-color: var(--bs-dark) !important;
   }
   
 }
+#home-link {
+  text-decoration: none;
+  color: inherit;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -22,7 +22,7 @@
 <body class="py-4">
     <div class="container">
 
-        <h1><a href="/" style="text-decoration: none; color: inherit;">TMPNOTES 🔥️</a></h1>
+        <h1><a id="home-link" href="/">TMPNOTES 🔥️</a></h1>
         <p class="lead">Temporary notes that disappear after reading</p>
 
         <h2>Note:</h2>

--- a/templates/404.html
+++ b/templates/404.html
@@ -18,7 +18,7 @@
 <body class="py-4">
     <div class="container">
 
-        <h1><a href="/" style="text-decoration: none; color: inherit;">TMPNOTES 🔥️</a></h1>
+        <h1><a id="home-link" href="/">TMPNOTES 🔥️</a></h1>
         <p class="lead">Temporary notes that disappear after reading</p>
         <h2>Nothing to see here 👀️</h2>
     </div>

--- a/templates/note.html
+++ b/templates/note.html
@@ -24,7 +24,7 @@
 <body class="py-4">
     <div class="container">
 
-        <h1><a href="/" style="text-decoration: none; color: inherit;">TMPNOTES 🔥️</a></h1>
+        <h1><a id="home-link" href="/">TMPNOTES 🔥️</a></h1>
         <p class="lead">Temporary notes that disappear after reading</p>
 
         <div class="row" id="get-note-row">


### PR DESCRIPTION
Apparently having in-line styles is not very secure, and makes creating a [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) difficult. 