### PR TITLE
Fixing config to bind on PORT env var

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 type specification struct {
-	Port     int    `default:"5000"`
+	Port     int    `default:"5000" envconfig:"PORT"`
 	RedisUrl string `default:"redis://localhost:6379" envconfig:"REDIS_URL"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,8 +14,8 @@ func Test_GetConfig(t *testing.T) {
 	}{
 		{
 			name: "Test 1",
-			args: map[string]string{"PORT": "5000", "REDIS_URL": "redis://localhost:1234"},
-			want: specification{Port: 5000, RedisUrl: "redis://localhost:1234"},
+			args: map[string]string{"PORT": "7000", "REDIS_URL": "redis://localhost:1234"},
+			want: specification{Port: 7000, RedisUrl: "redis://localhost:1234"},
 		},
 		{
 			name: "Test 2",


### PR DESCRIPTION
The test was passing before since it used the default value. Fixing the configuration and test :facepalm: 