### PR TITLE
Adding standard headers to responses for security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following table shows environment variables that can be used to configure yo
 |---------|------|-------------|---------|
 | `TMPNOTES_PORT` | int | Port number for the application to use. The env var `PORT` can also be used. | `5000` |
 | `TMPNOTES_REDIS_URL` | string | Redis URI / connection string. `REDIS_URL` can also be used. | `redis://localhost:6379` |
+| `TMPNOTES_ENABLE_HSTS` | bool | Return `"Strict-Transport-Security", "max-age=15552000"` header to enforce TLS for web browser clients. Only use this if you are sure your instance is running behind a reverse proxy with TLS. | `false` |
 
 ## docker-compose
 We have provided a `docker-compose` file to easily build and host a functional TMPNOTES system.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,8 +5,9 @@ import (
 )
 
 type specification struct {
-	Port     int    `default:"5000" envconfig:"PORT"`
-	RedisUrl string `default:"redis://localhost:6379" envconfig:"REDIS_URL"`
+	Port       int    `default:"5000" envconfig:"PORT"`
+	RedisUrl   string `default:"redis://localhost:6379" envconfig:"REDIS_URL"`
+	EnableHsts bool   `split_words:"true"`
 }
 
 var Config specification

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,12 +15,12 @@ func Test_GetConfig(t *testing.T) {
 		{
 			name: "Test 1",
 			args: map[string]string{"PORT": "7000", "REDIS_URL": "redis://localhost:1234"},
-			want: specification{Port: 7000, RedisUrl: "redis://localhost:1234"},
+			want: specification{Port: 7000, RedisUrl: "redis://localhost:1234", EnableHsts: false},
 		},
 		{
 			name: "Test 2",
-			args: map[string]string{"TMPNOTES_PORT": "6000", "TMPNOTES_REDIS_URL": "rediss://someserver:1234"},
-			want: specification{Port: 6000, RedisUrl: "rediss://someserver:1234"},
+			args: map[string]string{"TMPNOTES_PORT": "6000", "TMPNOTES_REDIS_URL": "rediss://someserver:1234", "TMPNOTES_ENABLE_HSTS": "true"},
+			want: specification{Port: 6000, RedisUrl: "rediss://someserver:1234", EnableHsts: true},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -1,0 +1,17 @@
+package headers
+
+import (
+	"net/http"
+
+	cfg "tmpnotes/internal/config"
+)
+
+func AddStandardHeaders(h http.Header) {
+	h.Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://cdn.jsdelivr.net")
+	h.Set("X-Frame-Options", "DENY")
+	h.Set("X-Content-Type-Options", "nosniff")
+	h.Set("X-XSS-Protection", "1; mode=block")
+	if cfg.Config.EnableHsts {
+		h.Set("Strict-Transport-Security", "max-age=15552000")
+	}
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
+
+	h "tmpnotes/internal/headers"
 )
 
 func HealthCheck(w http.ResponseWriter, r *http.Request) {
-
+	h.AddStandardHeaders(w.Header())
 	log.Info(r.RequestURI)
 
 	if r.Method == "GET" {

--- a/internal/notes/counts.go
+++ b/internal/notes/counts.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
+
+	h "tmpnotes/internal/headers"
 )
 
 type counts struct {
@@ -14,7 +16,7 @@ type counts struct {
 }
 
 func GetCounts(w http.ResponseWriter, r *http.Request) {
-
+	h.AddStandardHeaders(w.Header())
 	log.Info(r.RequestURI)
 
 	if r.Method != "GET" {

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -17,6 +17,7 @@ import (
 
 	cfg "tmpnotes/internal/config"
 	"tmpnotes/internal/crypto"
+	h "tmpnotes/internal/headers"
 )
 
 const maxLength = 1000
@@ -142,6 +143,7 @@ func GetNote(w http.ResponseWriter, r *http.Request) {
 	id := full[:8]
 	key := full[8:]
 	log.Info(id)
+	h.AddStandardHeaders(w.Header())
 
 	if r.Method != "GET" {
 		log.Errorf("%s Invalid request method: %s", id, r.Method)

--- a/static/createnote.js
+++ b/static/createnote.js
@@ -1,0 +1,63 @@
+document.addEventListener('keydown', countInput);
+document.addEventListener('keyup', countInput);
+document.getElementById("send-button").addEventListener("click", postInfo)
+document.getElementById("copy-button").addEventListener("click", copyLink)
+
+function countInput(e) {
+    const input = document.getElementById('notes-input');
+    const maxChars = 512
+    input.labels[0].innerText = input.textLength + "/" + maxChars
+}
+
+function postInfo() {
+    var e = document.getElementById("hours-input");
+    var hours = e.options[e.selectedIndex].text;
+    var e = document.getElementById("notes-input");
+    var key = document.getElementById("enc-key");
+    var note = encryptNote(e.value, key.value);
+    e.readOnly = true;
+    document.getElementById("send-button").style.visibility = "hidden";
+    var data = { "message": note, "expire": parseInt(hours) }
+    var opts = {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+    }
+
+    var req = new Request(location.origin + "/new", opts)
+
+    fetch(req).then(function (response) {
+        return response.text().then(function (text) {
+            e = document.getElementById("note-id");
+            e.value = location.origin + "/id/" + text;
+        });
+    })
+        .catch(error => {
+            console.log('request failed', error);
+            alert("Unable to reach the server. Try again later.")
+            throw error;
+        });
+
+    e = document.getElementById("note-id");
+    e.style.visibility = "visible";
+    document.getElementById("copy-button").style.visibility = "visible";
+    document.getElementById("encrypt-row").remove();
+}
+
+function copyLink() {
+    let noteid = document.getElementById("note-id");
+    noteid.select();
+    document.execCommand('copy');
+}
+
+// encrypt the note if an encryption key is provided
+function encryptNote(note, key) {
+    if (key.length > 0) {
+        var ciphertext = CryptoJS.AES.encrypt(note, key);
+        return "[ENC]" + ciphertext.toString()
+    } else {
+        return note;
+    }
+}

--- a/static/custom.css
+++ b/static/custom.css
@@ -1,7 +1,9 @@
-body { background-color: var(--bs-dark) !important;
-       color: var(--bs-light);
+body {
+  background-color: var(--bs-dark) !important;
+  color: var(--bs-light);
 }
-.row{
+
+.row {
   margin-bottom: 5%;
   --bs-gutter-x: 0;
 }
@@ -10,7 +12,7 @@ body { background-color: var(--bs-dark) !important;
   width: 99%;
 }
 
-.footer{
+.footer {
   display: table;
   text-align: center;
   margin-left: auto;
@@ -25,9 +27,33 @@ body { background-color: var(--bs-dark) !important;
     font-size: small;
     text-align: left;
   }
-  
+
 }
+
 #home-link {
   text-decoration: none;
   color: inherit;
+}
+
+#note-id {
+  visibility: hidden;
+  text-align: center;
+}
+
+#footer-container {
+  border: 1px solid white;
+}
+
+#copy-button,
+#dec-button,
+#notification-row,
+#note-row,
+#dec-input {
+  visibility: hidden;
+}
+
+
+#gh-button-star,
+#gh-button-issue {
+  padding: unset;
 }

--- a/static/getnote.js
+++ b/static/getnote.js
@@ -1,0 +1,73 @@
+document.getElementById("dec-button").addEventListener("click", decryptNote)
+document.getElementById("copy-note-button").addEventListener("click", copyNote)
+document.getElementById("get-note-button").addEventListener("click", getNote)
+
+async function getNote() {
+    var opts = {
+        method: 'GET',
+        headers: {
+            'X-Note': 'Destroy'
+        },
+    }
+
+    var req = new Request(location.href, opts)
+
+    await fetch(req)
+        .then(function (response) {
+            if (!response.ok) {
+                location.reload()
+            } else {
+                return response.text().then(function (text) {
+                    document.getElementById("note-row").style.visibility = "visible"
+                    document.getElementById("notification-row").style.visibility = "visible"
+                    document.getElementById("note").value = text
+                    document.getElementById("get-note-row").remove()
+                    checkDecryptionRequired()
+                });
+            }
+        })
+        .catch(error => {
+            console.log('request failed', error);
+            alert("Unable to reach the server. Try again later.")
+            throw error;
+        });
+}
+
+function copyNote() {
+    let textarea = document.getElementById("note");
+    textarea.select();
+    document.execCommand("copy");
+}
+
+function checkDecryptionRequired() {
+    note = document.getElementById("note");
+    if (note.value.startsWith("[ENC]")) {
+        e = document.getElementById("dec-button");
+        e.style.visibility = "visible";
+        e = document.getElementById("dec-input");
+        e.style.visibility = "visible";
+    } else {
+        document.getElementById("decrypt-row").remove()
+    }
+}
+
+function decryptNote() {
+    note = document.getElementById("note");
+    notetext = note.value.replace("[ENC]", "");
+    key = document.getElementById("dec-key").value;
+
+    try {
+        var bytes = CryptoJS.AES.decrypt(notetext, key);
+        var res = bytes.toString(CryptoJS.enc.Utf8);
+
+        if (res != "") {
+            note.value = res
+            document.getElementById("decrypt-row").remove()
+        } else {
+            alert("Decryption failed")
+        }
+    } catch (error) {
+        console.error(error);
+        alert("Decryption failed")
+    }
+}

--- a/static/index.html
+++ b/static/index.html
@@ -16,7 +16,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"
         integrity="sha512-E8QSvWZ0eCLGk4km3hxSsNmGWbLtSCSUcewDQPQWZF6pEU8GlT8a5fF32wOl1i8ftdMhssTrF/OhyGWwonTcXA=="
         crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+    <script src="createnote.js" defer></script>
 </head>
 
 <body class="py-4">
@@ -63,8 +64,7 @@
                 </div>
                 <div class="row">
                     <br>
-                    <button type="submit" id="send-button" class="btn btn-primary btn-block"
-                        onclick="postInfo()">Send</button>
+                    <button type="submit" id="send-button" class="btn btn-primary btn-block">Send</button>
                 </div>
             </div>
         </div>
@@ -84,92 +84,49 @@
         <div class="row">
             <div class="col-lg-9">
                 <div class="form-group">
-                    <input type="text" class="form-control mt-1" id="note-id"
-                        style="visibility: hidden; text-align: center;" readonly>
+                    <input type="text" class="form-control mt-1" id="note-id" readonly>
                 </div>
             </div>
             <div class="col-lg d-grid">
-                <button type="submit" id="copy-button" class="btn btn-primary mb-2 btn-block mt-1" onclick="copyLink()"
-                    style="visibility: hidden;">copy</button>
+                <button type="submit" id="copy-button" class="btn btn-primary mb-2 btn-block mt-1">copy</button>
             </div>
         </div>
     </div>
 </body>
-<div class="container" style="border:1px solid white;">
+<div class="container" id="footer-container">
     <div class="footer">
         <div>
             <p>ABOUT TMPNOTES</p>
-            <p>Thanks for using TMPNOTES! TMPNOTES is an open source project that allows notes to be passed simply and securely.</p>
-            <p>Like the concept of TMPNOTES but don't trust those hosting it? Feel free to host it yourself - <a href="https://github.com/soraro/tmpnotes#run-it-yourself">self hosting instructions</a>.</p>
-            <p>Enjoy using TMPNOTES? Give our GitHub repo a star! <a class="github-button" href="https://github.com/soraro/tmpnotes" data-icon="octicon-star" aria-label="Star soraro/tmpnotes on GitHub">Star</a></p>
-            <p>Running into bugs? Missing a feature you want? Create an issue! <a class="github-button" href="https://github.com/soraro/tmpnotes/issues" data-icon="octicon-issue-opened" aria-label="Issue soraro/tmpnotes on GitHub">Issue</a></p>
+            <p>Thanks for using TMPNOTES! TMPNOTES is an open source project that allows notes to be passed simply and
+                securely.</p>
+            <p>Like the concept of TMPNOTES but don't trust those hosting it? Feel free to host it yourself - <a
+                    href="https://github.com/soraro/tmpnotes#run-it-yourself">self hosting instructions</a>.</p>
+            <p>Enjoy using TMPNOTES? Give our GitHub repo a star!
+                <a href="https://github.com/soraro/tmpnotes">
+                    <button type="button" class="btn btn-primary" id="gh-button-star">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
+                            class="bi bi-star-fill" viewBox="0 0 16 16">
+                            <path
+                                d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z">
+                            </path>
+                        </svg>
+                        <span>Star</span>
+                    </button>
+                </a>
+            </p>
+            <p>Running into bugs? Missing a feature you want? Create an issue!
+                <a href="https://github.com/soraro/tmpnotes/issues">
+                    <button type="button" class="btn btn-primary" id="gh-button-issue">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                            class="bi bi-github" viewBox="0 0 16 16">
+                            <path
+                                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                        </svg>
+                        <span>Issue</span>
+                    </button>
+                </a>
         </div>
     </div>
 </div>
 
 </html>
-
-
-<script>
-    const input = document.getElementById('notes-input');
-    const maxChars = 512
-    document.addEventListener('keydown', countInput);
-    document.addEventListener('keyup', countInput);
-
-    function countInput(e) {
-        input.labels[0].innerText = input.textLength + "/" + maxChars
-    }
-
-    async function postInfo() {
-        var e = document.getElementById("hours-input");
-        var hours = e.options[e.selectedIndex].text;
-        var e = document.getElementById("notes-input");
-        var key = document.getElementById("enc-key");
-        var note = encryptNote(e.value, key.value);
-        e.readOnly = true;
-        document.getElementById("send-button").style.visibility = "hidden";
-        var data = { "message": note, "expire": parseInt(hours) }
-        var opts = {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(data)
-        }
-
-        var req = new Request(location.origin + "/new", opts)
-
-        await fetch(req).then(function (response) {
-            return response.text().then(function (text) {
-                e = document.getElementById("note-id");
-                e.value = location.origin + "/id/" + text;
-            });
-        })
-            .catch(error => {
-                console.log('request failed', error);
-                alert("Unable to reach the server. Try again later.")
-                throw error;
-            });
-
-        e = document.getElementById("note-id");
-        e.style.visibility = "visible";
-        document.getElementById("copy-button").style.visibility = "visible";
-        document.getElementById("encrypt-row").remove();
-    }
-
-    function copyLink() {
-        let noteid = document.getElementById("note-id");
-        noteid.select();
-        document.execCommand('copy');
-    }
-
-    // encrypt the note if an encryption key is provided
-    function encryptNote(note, key) {
-        if (key.length > 0) {
-            var ciphertext = CryptoJS.AES.encrypt(note, key);
-            return "[ENC]" + ciphertext.toString()
-        } else {
-            return note;
-        }
-    }
-</script>

--- a/templates/404.html
+++ b/templates/404.html
@@ -23,15 +23,38 @@
         <h2>Nothing to see here 👀️</h2>
     </div>
 </body>
-
-<div class="container" style="border:1px solid white;">
+<div class="container" id="footer-container">
     <div class="footer">
         <div>
             <p>ABOUT TMPNOTES</p>
-            <p>Thanks for using TMPNOTES! TMPNOTES is an open source project that allows notes to be passed simply and securely.</p>
-            <p>Like the concept of TMPNOTES but don't trust those hosting it? Feel free to host it yourself - <a href="https://github.com/soraro/tmpnotes#run-it-yourself">self hosting instructions</a>.</p>
-            <p>Enjoy using TMPNOTES? Give our GitHub repo a star! <a class="github-button" href="https://github.com/soraro/tmpnotes" data-icon="octicon-star" aria-label="Star soraro/tmpnotes on GitHub">Star</a></p>
-            <p>Running into bugs? Missing a feature you want? Create an issue! <a class="github-button" href="https://github.com/soraro/tmpnotes/issues" data-icon="octicon-issue-opened" aria-label="Issue soraro/tmpnotes on GitHub">Issue</a></p>
+            <p>Thanks for using TMPNOTES! TMPNOTES is an open source project that allows notes to be passed simply and
+                securely.</p>
+            <p>Like the concept of TMPNOTES but don't trust those hosting it? Feel free to host it yourself - <a
+                    href="https://github.com/soraro/tmpnotes#run-it-yourself">self hosting instructions</a>.</p>
+            <p>Enjoy using TMPNOTES? Give our GitHub repo a star!
+                <a href="https://github.com/soraro/tmpnotes">
+                    <button type="button" class="btn btn-primary" id="gh-button-star">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
+                            class="bi bi-star-fill" viewBox="0 0 16 16">
+                            <path
+                                d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z">
+                            </path>
+                        </svg>
+                        <span>Star</span>
+                    </button>
+                </a>
+            </p>
+            <p>Running into bugs? Missing a feature you want? Create an issue!
+                <a href="https://github.com/soraro/tmpnotes/issues">
+                    <button type="button" class="btn btn-primary" id="gh-button-issue">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                            class="bi bi-github" viewBox="0 0 16 16">
+                            <path
+                                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                        </svg>
+                        <span>Issue</span>
+                    </button>
+                </a>
         </div>
     </div>
 </div>

--- a/templates/404.html
+++ b/templates/404.html
@@ -12,7 +12,6 @@
 
     <!-- Custom styles for this template -->
     <link href="/custom.css" rel="stylesheet">
-    <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 
 <body class="py-4">

--- a/templates/note.html
+++ b/templates/note.html
@@ -18,6 +18,7 @@
         crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <script src="/getnote.js" defer></script>
 
 </head>
 
@@ -28,10 +29,10 @@
         <p class="lead">Temporary notes that disappear after reading</p>
 
         <div class="row" id="get-note-row">
-            <button type="submit" class="btn btn-primary mb-2 btn-block mt-1" onclick="getNote()">Get Note</button>
+            <button type="submit" class="btn btn-primary mb-2 btn-block mt-1" id="get-note-button">Get Note</button>
             <p>Once you click this, you will not be able to read the note again!</p>
         </div>
-        <div class="row" id="note-row" style="visibility: hidden;">
+        <div class=" row" id="note-row">
             <h2>Note:</h2>
             <div class="col-lg-9">
                 <textarea class="form-control" id="note" rows="7" readonly>Get the note first...</textarea>
@@ -39,13 +40,14 @@
             <div class="col">
                 <div class="row">
                     <br>
-                    <button type="submit" class="btn btn-primary mb-2 btn-block mt-1" onclick="copyNote()">Copy</button>
+                    <button type="submit" class="btn btn-primary mb-2 btn-block mt-1"
+                        id="copy-note-button">Copy</button>
                 </div>
             </div>
         </div>
         <div class="row" id="decrypt-row">
             <div class="col-lg-9">
-                <div id="dec-input" class="form-group" style="visibility: hidden;">
+                <div id="dec-input" class="form-group">
                     <label for="dec-key">Decryption key</label>
                     <input type="password" class="form-control" id="dec-key" placeholder="Your passphrase here">
                 </div>
@@ -54,99 +56,51 @@
                 <div class="row">
                     <p></p>
                     <br>
-                    <button id="dec-button" type="submit" class="btn btn-primary mb-2 btn-block mt-1"
-                        onclick="decryptNote()" style="visibility: hidden;">Decrypt</button>
+                    <button id="dec-button" type="submit" class="btn btn-primary mb-2 btn-block mt-1">Decrypt</button>
                 </div>
             </div>
         </div>
-        <div class="row" id="notification-row" style="visibility: hidden;">
+        <div class="row" id="notification-row">
             <div class="col">
                 🔥️ It's gone! Now that this has been read, you will not be able to see this note again. 🔥️
             </div>
         </div>
     </div>
 </body>
-<div class="container" style="border:1px solid white;">
+<div class="container" id="footer-container">
     <div class="footer">
         <div>
             <p>ABOUT TMPNOTES</p>
-            <p>Thanks for using TMPNOTES! TMPNOTES is an open source project that allows notes to be passed simply and securely.</p>
-            <p>Like the concept of TMPNOTES but don't trust those hosting it? Feel free to host it yourself - <a href="https://github.com/soraro/tmpnotes#run-it-yourself">self hosting instructions</a>.</p>
-            <p>Enjoy using TMPNOTES? Give our GitHub repo a star! <a class="github-button" href="https://github.com/soraro/tmpnotes" data-icon="octicon-star" aria-label="Star soraro/tmpnotes on GitHub">Star</a></p>
-            <p>Running into bugs? Missing a feature you want? Create an issue! <a class="github-button" href="https://github.com/soraro/tmpnotes/issues" data-icon="octicon-issue-opened" aria-label="Issue soraro/tmpnotes on GitHub">Issue</a></p>
+            <p>Thanks for using TMPNOTES! TMPNOTES is an open source project that allows notes to be passed simply and
+                securely.</p>
+            <p>Like the concept of TMPNOTES but don't trust those hosting it? Feel free to host it yourself - <a
+                    href="https://github.com/soraro/tmpnotes#run-it-yourself">self hosting instructions</a>.</p>
+            <p>Enjoy using TMPNOTES? Give our GitHub repo a star!
+                <a href="https://github.com/soraro/tmpnotes">
+                    <button type="button" class="btn btn-primary" id="gh-button-star">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
+                            class="bi bi-star-fill" viewBox="0 0 16 16">
+                            <path
+                                d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z">
+                            </path>
+                        </svg>
+                        <span>Star</span>
+                    </button>
+                </a>
+            </p>
+            <p>Running into bugs? Missing a feature you want? Create an issue!
+                <a href="https://github.com/soraro/tmpnotes/issues">
+                    <button type="button" class="btn btn-primary" id="gh-button-issue">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                            class="bi bi-github" viewBox="0 0 16 16">
+                            <path
+                                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                        </svg>
+                        <span>Issue</span>
+                    </button>
+                </a>
         </div>
     </div>
 </div>
+
 </html>
-
-<script>
-    async function getNote() {
-        var opts = {
-            method: 'GET',
-            headers: {
-                'X-Note': 'Destroy'
-            },
-        }
-
-        var req = new Request(location.href, opts)
-
-        await fetch(req)
-            .then(function (response) {
-                if (!response.ok) {
-                    location.reload()
-                } else {
-                    return response.text().then(function (text) {
-                        document.getElementById("note-row").style.visibility = "visible"
-                        document.getElementById("notification-row").style.visibility = "visible"
-                        document.getElementById("note").value = text
-                        document.getElementById("get-note-row").remove()
-                        checkDecryptionRequired()
-                    });
-                }
-            })
-            .catch(error => {
-                console.log('request failed', error);
-                alert("Unable to reach the server. Try again later.")
-                throw error;
-            });
-    }
-
-    function copyNote() {
-        let textarea = document.getElementById("note");
-        textarea.select();
-        document.execCommand("copy");
-    }
-
-    function checkDecryptionRequired() {
-        note = document.getElementById("note");
-        if (note.value.startsWith("[ENC]")) {
-            e = document.getElementById("dec-button");
-            e.style.visibility = "visible";
-            e = document.getElementById("dec-input");
-            e.style.visibility = "visible";
-        } else {
-            document.getElementById("decrypt-row").remove()
-        }
-    }
-
-    function decryptNote() {
-        note = document.getElementById("note");
-        notetext = note.value.replace("[ENC]", "");
-        key = document.getElementById("dec-key").value;
-
-        try {
-            var bytes = CryptoJS.AES.decrypt(notetext, key);
-            var res = bytes.toString(CryptoJS.enc.Utf8);
-
-            if (res != "") {
-                note.value = res
-                document.getElementById("decrypt-row").remove()
-            } else {
-                alert("Decryption failed")
-            }
-        } catch (error) {
-            console.error(error);
-            alert("Decryption failed")
-        }
-    }
-</script>

--- a/templates/note.html
+++ b/templates/note.html
@@ -17,7 +17,6 @@
         integrity="sha512-E8QSvWZ0eCLGk4km3hxSsNmGWbLtSCSUcewDQPQWZF6pEU8GlT8a5fF32wOl1i8ftdMhssTrF/OhyGWwonTcXA=="
         crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-    <script async defer src="https://buttons.github.io/buttons.js"></script>
     <script src="/getnote.js" defer></script>
 
 </head>


### PR DESCRIPTION
This PR is primarily for adding standard headers to tmpnotes responses that add browser security protections such as Content Security Policy. The bulk of the changes here are refactoring the HTML so it does not include inline styles and scripts so they can be explicitly called out in the CSP and not have exceptions made for `unsafe-inline`. 

Additionally, there is a new env var/config for enabling HSTS that people can use assuming they are hosting a tmpnotes instance behind a reverse proxy with TLS. Generally these headers would be added on a reverse proxy, but to make it more of a "secure by default" approach, we are adding them directly into the application. 

Closes #27 and closes #28 since this PR includes those header responses.