### PR TITLE
return 500 if redis is not available

### DIFF
--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -83,6 +83,8 @@ func AddNote(w http.ResponseWriter, r *http.Request) {
 	_, err = pipe.Exec(ctx)
 	if err != nil {
 		log.Errorf("%s Error setting note values: %s", r.RequestURI, err)
+		http.Error(w, "Error connecting to database", 500)
+		return
 	}
 
 	fmt.Fprint(w, id+key)

--- a/static/createnote.js
+++ b/static/createnote.js
@@ -15,8 +15,6 @@ function postInfo() {
     var e = document.getElementById("notes-input");
     var key = document.getElementById("enc-key");
     var note = encryptNote(e.value, key.value);
-    e.readOnly = true;
-    document.getElementById("send-button").style.visibility = "hidden";
     var data = { "message": note, "expire": parseInt(hours) }
     var opts = {
         method: 'POST',
@@ -29,10 +27,21 @@ function postInfo() {
     var req = new Request(location.origin + "/new", opts)
 
     fetch(req).then(function (response) {
-        return response.text().then(function (text) {
-            e = document.getElementById("note-id");
-            e.value = location.origin + "/id/" + text;
-        });
+        if (response.status === 500) {
+            console.log('note creation failed')
+            alert("Can't connect to the database. Try again later.")
+        } else {
+            return response.text().then(function (text) {
+                document.getElementById("send-button").style.visibility = "hidden";
+                e.readOnly = true;
+                e = document.getElementById("note-id");
+                e.value = location.origin + "/id/" + text;
+                e = document.getElementById("note-id");
+                e.style.visibility = "visible";
+                document.getElementById("copy-button").style.visibility = "visible";
+                document.getElementById("encrypt-row").remove();
+            });
+        }
     })
         .catch(error => {
             console.log('request failed', error);
@@ -40,10 +49,6 @@ function postInfo() {
             throw error;
         });
 
-    e = document.getElementById("note-id");
-    e.style.visibility = "visible";
-    document.getElementById("copy-button").style.visibility = "visible";
-    document.getElementById("encrypt-row").remove();
 }
 
 function copyLink() {


### PR DESCRIPTION
Closes #39 

Fixes issue where tmpnotes server returns a UUID and URL in the UI even when Redis is not available. 

Current state:
Start a local tmpnotes instance **without redis** and go to http://localhost:5000 and create a note. The UI will return a URL. This URL will result in a Server Error.

This PR:
Start a local tmpnotes instance **without redis**  and go to http://localhost:5000 and create a note. This should cause an alert to pop up and say the database is not available.
